### PR TITLE
Unity 2017 login fail fix

### DIFF
--- a/Assets/Plugins/GameJolt/Scripts/API/Core/Response.cs
+++ b/Assets/Plugins/GameJolt/Scripts/API/Core/Response.cs
@@ -80,7 +80,7 @@ namespace GameJolt.API.Core
 		/// <param name="format">The format of the response.</param>
 		public Response(WWW www, ResponseFormat format = ResponseFormat.Json)
 		{
-			if (www.error != null && !string.IsNullOrEmpty(www.error))
+			if (!string.IsNullOrEmpty(www.error))
 			{
 				this.success = false;
 				Debug.LogWarning(www.error);

--- a/Assets/Plugins/GameJolt/Scripts/API/Core/Response.cs
+++ b/Assets/Plugins/GameJolt/Scripts/API/Core/Response.cs
@@ -80,7 +80,7 @@ namespace GameJolt.API.Core
 		/// <param name="format">The format of the response.</param>
 		public Response(WWW www, ResponseFormat format = ResponseFormat.Json)
 		{
-			if (www.error != null)
+			if (www.error != null && !string.IsNullOrEmpty(www.error))
 			{
 				this.success = false;
 				Debug.LogWarning(www.error);


### PR DESCRIPTION
Fix for Unity 2017 always giving 'Wrong username and/or token.' error on login.